### PR TITLE
Update Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ man_MANS += doc/knockd.1
 sysconf_DATA = knockd.conf
 endif
 
-dist_doc_DATA = README TODO ChangeLog COPYING
+dist_doc_DATA = README.md TODO ChangeLog COPYING
 
 knock_SOURCES = src/knock.c
 knockd_SOURCES = src/knockd.c src/list.c src/list.h


### PR DESCRIPTION
Fix build failure due to missing README file.

The build process fails because Makefile.am includes README as part of the documentation files, but actually it doesn't exist:

make[2]: **\* No rule to make target `README', needed by`all-am'. Stop.

The right file is README.md, so making that replacement to Makefile.am fixes the problem.
