### PR TITLE
knock_add shell script which prevents duplicate ACCEPT rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ man_MANS = doc/knock.1
 
 if BUILD_KNOCKD
 sbin_PROGRAMS = knockd
+dist_sbin_SCRIPTS = src/utils/knock_add
 man_MANS += doc/knockd.1
 sysconf_DATA = knockd.conf
 endif

--- a/knockd.conf
+++ b/knockd.conf
@@ -4,7 +4,7 @@
 [openSSH]
 	sequence    = 7000,8000,9000
 	seq_timeout = 5
-	command     = /usr/local/sbin/knock_add %IP%
+	command     = /usr/local/sbin/knock_add -c 'INPUT' -t tcp -p 22 -a %IP%
 	tcpflags    = syn
 
 [closeSSH]

--- a/knockd.conf
+++ b/knockd.conf
@@ -4,7 +4,7 @@
 [openSSH]
 	sequence    = 7000,8000,9000
 	seq_timeout = 5
-	command     = /usr/sbin/iptables -A INPUT -s %IP% -p tcp --dport 22 -j ACCEPT
+	command     = /usr/local/sbin/knock_add %IP%
 	tcpflags    = syn
 
 [closeSSH]

--- a/src/utils/knock_add
+++ b/src/utils/knock_add
@@ -4,35 +4,37 @@ SCRIPT_NAME=$(basename $0)
 
 AWK="/bin/awk"
 GREP="/bin/grep"
-IPTABLES="/sbin/iptables"
+IPTABLES="/usr/sbin/iptables"
 SORT="/bin/sort"
+
+DEFAULT_COMMENT="Added by knockd - ssh"
 
 ADD_CHAIN="INPUT"
 ADD_COMMENT=""
-ADD_METHOD="-I"
+ADD_IP=""
+ADD_METHOD="insert"
 ADD_PORT="22"
 ADD_PROTOCOL="tcp"
 
-COMMENT=0
-DEFAULT_COMMENT="Added by knockd - ssh"
 DRY_RUN=0
 SEEN=0
 VERBOSE=0
 
 usage() {
-	echo "usage: $SCRIPT_NAME [-d|-h|-v] IPADDR"
+	echo "usage: $SCRIPT_NAME [OPTIONS] -a IPADDR"
 	echo "Options:"
+	echo "-a|--address     The IP address to add"
 	echo "-c|--chain       The NetFilter chain to add this address to"
 	echo "-d|--dry-run     Don't actually add IPADDR to $ADD_CHAIN chain"
 	echo "-h|--help        Print this informational screen and exit"
 	echo "-i|--insert      The method to use when adding the rule to NetFilter; valid values are: append, insert"
-	echo "-m|--comment     If present with argument will use that as a comment, if no arg use a boilerplate comment"
+	echo "-m|--comment     If present with optional argument will use that as a comment, if no argument use a boilerplate comment"
 	echo "-p|--port        The port to add allow for default: $ADD_PORT"
 	echo "-t|--protocol    The protocol to add allow for (i.e. tcp, udp) default: $ADD_PROTOCOL"
 	echo "-v|--verbose     Print verbose information about actions"
 }
 
-ARGS=$(getopt -o c:dhv -l "comment:,dry-run,help,verbose" -n $SCRIPT_NAME -- "$@")
+ARGS=$(getopt -o a:c:dhi:m::p:t:v -l "address:,chain:,comment::,dry-run,help,insert:,port:,protocol:,verbose" -n $SCRIPT_NAME -- "$@")
 
 if [ $? -ne 0 ];
 then
@@ -45,17 +47,15 @@ eval set -- "$ARGS"
 
 while true; do
         case "$1" in
-		-c|--comment)
-			shift;
-			COMMENT=1
-			if [ -n "$1" ]; then
-				ADD_COMENT=$1
-				shift;
-			else
-				ADD_COMMENT=$DEFAULT_COMMENT
-			fi
+		-a|--address)
+			ADD_IP=$2
+			shift 2;
 		;;
-                -d|--dry-run)
+		-c|--chain)
+			ADD_CHAIN=$2
+			shift 2;
+		;;
+		-d|--dry-run)
 			DRY_RUN=1
                         shift;
                 ;;
@@ -63,6 +63,28 @@ while true; do
 			usage
 			shift;
 			exit
+		;;
+		-i|--insert)
+			ADD_METHOD=$2
+			shift 2;
+		;;
+		-m|--comment)
+			case "$2" in
+				"")
+					ADD_COMMENT=$DEFAULT_COMMENT;
+					shift 2;;
+				*)
+					ADD_COMMENT=$2;
+					shift 2 ;;
+			esac
+		;;
+		-p|--port)
+			ADD_PORT=$2
+			shift 2;
+		;;
+		-t|--protocol)
+			ADD_PROTOCOL=$2
+			shift 2;
 		;;
 		-v|--verbose)
 			VERBOSE=1
@@ -75,12 +97,52 @@ while true; do
         esac
 done
 
-ADD_IP=$1
+#if [ -z "$1" ]; then
+#	echo "error: ip address required"
+#	usage
+#	exit 1
+#fi
+#
+#ADD_IP=$1
+
+if [ -z "$ADD_IP" ]; then
+	echo "error: ip address required"
+	usage
+	exit 1
+fi
 
 if [ "$VERBOSE" -eq 1 ]; then
 	echo "Testing $ADD_IP"
 fi
 
+# Sanity checking options
+case "$ADD_METHOD" in
+	insert)
+		ADD_METHOD="-I"
+	;;
+	append)
+		ADD_METHOD="-A"
+	;;
+	*)
+		echo "error: Invalid insert value"
+		usage
+		exit 1
+	;;
+esac
+
+COMMENT=""
+if [ -n "$ADD_COMMENT" ]; then
+	COMMENT="-m comment --comment '$ADD_COMMENT'"
+fi
+
+$IPTABLES -L $ADD_CHAIN &> /dev/null
+if [ 0 -ne "$?" ]; then
+	echo "error: $ADD_CHAIN is not a valid NetFilter chain"
+	exit
+fi
+# End Sanity Checks
+
+# Dupe checking
 for IP in `$IPTABLES -n -L KNOCKD | $GREP ACCEPT | $AWK '{print $4}' | $SORT -u`;
 do
 	if [ "$VERBOSE" -eq 1 ]; then
@@ -96,13 +158,14 @@ if [ "$VERBOSE" -eq 1 ]; then
 	echo "SEEN: $SEEN"
 fi
 
+
 if [ "$SEEN" -eq 0 ]; then
 	if [ "$VERBOSE" -eq 1 ]; then
 		echo "Adding $ADD_IP"
-		echo $IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT
+		echo $IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT $COMMENT
 	fi
 
 	if [ "$DRY_RUN" -eq 0 ]; then
-		$IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT
+		eval $IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT $COMMENT
 	fi
 fi

--- a/src/utils/knock_add
+++ b/src/utils/knock_add
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+SCRIPT_NAME=$(basename $0)
+
+AWK="/bin/awk"
+GREP="/bin/grep"
+IPTABLES="/sbin/iptables"
+SORT="/bin/sort"
+
+ADD_CHAIN="INPUT"
+ADD_COMMENT="Added by knockd - ssh"
+ADD_PORT="22"
+DRY_RUN=0
+SEEN=0
+VERBOSE=0
+
+usage() {
+	echo "usage: $SCRIPT_NAME [-d|-h|-v] IPADDR"
+	echo "Options:"
+	echo "-d|--dry-run     Don't actually add IPADDR to $ADD_CHAIN chain"
+	echo "-h|--help        Print this informational screen and exit"
+	echo "-v|--verbose     Print verbose information about actions"
+}
+
+ARGS=$(getopt -o dhv -l "dry-run,help,verbose" -n $SCRIPT_NAME -- "$@")
+
+if [ $? -ne 0 ];
+then
+        echo "Bad arguments"
+        usage
+        exit 1
+fi
+
+eval set -- "$ARGS"
+
+while true; do
+        case "$1" in
+                -d|--dry-run)
+			DRY_RUN=1
+                        shift;
+                ;;
+		-h|--help)
+			usage
+			shift;
+			exit
+		;;
+		-v|--verbose)
+			VERBOSE=1
+			shift;
+		;;
+                --)
+                        shift;
+                        break;
+                ;;
+        esac
+done
+
+ADD_IP=$1
+
+if [ "$VERBOSE" -eq 1 ]; then
+	echo "Testing $ADD_IP"
+fi
+
+for IP in `$IPTABLES -n -L KNOCKD | $GREP ACCEPT | $AWK '{print $4}' | $SORT -u`;
+do
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "$IP"
+	fi
+
+	if [ "$ADD_IP" == "$IP" ]; then
+		SEEN=1
+	fi
+done
+
+if [ "$VERBOSE" -eq 1 ]; then
+	echo "SEEN: $SEEN"
+fi
+
+if [ "$SEEN" -eq 0 ]; then
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "Adding $ADD_IP"
+	fi
+
+	if [ "$DRY_RUN" -eq 0 ]; then
+		$IPTABLES -A $ADD_CHAIN -s $ADD_IP -p tcp --dport $ADD_PORT -j ACCEPT
+	fi
+fi

--- a/src/utils/knock_add
+++ b/src/utils/knock_add
@@ -8,8 +8,13 @@ IPTABLES="/sbin/iptables"
 SORT="/bin/sort"
 
 ADD_CHAIN="INPUT"
-ADD_COMMENT="Added by knockd - ssh"
+ADD_COMMENT=""
+ADD_METHOD="-I"
 ADD_PORT="22"
+ADD_PROTOCOL="tcp"
+
+COMMENT=0
+DEFAULT_COMMENT="Added by knockd - ssh"
 DRY_RUN=0
 SEEN=0
 VERBOSE=0
@@ -17,12 +22,17 @@ VERBOSE=0
 usage() {
 	echo "usage: $SCRIPT_NAME [-d|-h|-v] IPADDR"
 	echo "Options:"
+	echo "-c|--chain       The NetFilter chain to add this address to"
 	echo "-d|--dry-run     Don't actually add IPADDR to $ADD_CHAIN chain"
 	echo "-h|--help        Print this informational screen and exit"
+	echo "-i|--insert      The method to use when adding the rule to NetFilter; valid values are: append, insert"
+	echo "-m|--comment     If present with argument will use that as a comment, if no arg use a boilerplate comment"
+	echo "-p|--port        The port to add allow for default: $ADD_PORT"
+	echo "-t|--protocol    The protocol to add allow for (i.e. tcp, udp) default: $ADD_PROTOCOL"
 	echo "-v|--verbose     Print verbose information about actions"
 }
 
-ARGS=$(getopt -o dhv -l "dry-run,help,verbose" -n $SCRIPT_NAME -- "$@")
+ARGS=$(getopt -o c:dhv -l "comment:,dry-run,help,verbose" -n $SCRIPT_NAME -- "$@")
 
 if [ $? -ne 0 ];
 then
@@ -35,6 +45,16 @@ eval set -- "$ARGS"
 
 while true; do
         case "$1" in
+		-c|--comment)
+			shift;
+			COMMENT=1
+			if [ -n "$1" ]; then
+				ADD_COMENT=$1
+				shift;
+			else
+				ADD_COMMENT=$DEFAULT_COMMENT
+			fi
+		;;
                 -d|--dry-run)
 			DRY_RUN=1
                         shift;
@@ -79,9 +99,10 @@ fi
 if [ "$SEEN" -eq 0 ]; then
 	if [ "$VERBOSE" -eq 1 ]; then
 		echo "Adding $ADD_IP"
+		echo $IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT
 	fi
 
 	if [ "$DRY_RUN" -eq 0 ]; then
-		$IPTABLES -A $ADD_CHAIN -s $ADD_IP -p tcp --dport $ADD_PORT -j ACCEPT
+		$IPTABLES $ADD_METHOD $ADD_CHAIN -s $ADD_IP -p $ADD_PROTOCOL --dport $ADD_PORT -j ACCEPT
 	fi
 fi


### PR DESCRIPTION
Using the iptables command directly from the knockd.conf file works well but will create duplicate entries for systems that knock multiple times. We have a Nessus scanner that manages to create many allow rules via knockd that never get cleaned up. These changes would add a shell script that does duplicate checking while still allowing configurability. The path to iptables will currently need to be set in the shell script after installation if different then the knockd.conf default. That could be changed to do a $(which iptables) if desired.

Feedback and recommendations welcome if this seems valuable. Thanks for your time!