### PR TITLE
fix generated libpcap filter expression for tcp-push

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -904,7 +904,7 @@ void generate_pcap_filter()
 				}
 			}
 			if(door->flag_psh != DONT_CARE) {
-				bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-psh ", bufsize);
+				bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-push ", bufsize);
 				if(door->flag_psh == SET) {
 					bufsize = realloc_strcat(&buffer, "!= 0", bufsize);
 				}


### PR DESCRIPTION
Libpcap understands "tcp-push", not "tcp-psh". Previously, a config file
containing "tcpflags = psh" would cause knockd to fail to start.