### PR TITLE
Fixes to issues #2 and #26 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 *.o
 *~
 .deps
+.dirstamp
 /Makefile
 /Makefile.in
 /aclocal.m4
 /autom4te.cache/
+/compile
 /config.h
 /config.h.in
 /config.log

--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
- 		59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.7.6         - Fix for Issue #13 where similar sequences are not detected
+                correctly.
 0.7.5         - Added Greg Kuchyt's knock_add script but updated to be a
                 generic IPTables helper that also deletes rules
 0.7.4         - Patches from Michael Göhler

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,9 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
-0.7.4         - Patches from Michael Göhler
+0.7.4         - Patches from Michael GÃ¶hler
                 - Updated gitignore to include additional autoconf files.
                 - Updated Makefile to fix deprecated warning on CPPFLAG
 		- -D_BSD_SOURCE.
-              - Patches from Christos Triantafyllidis
-                - Updated FSF address.
 0.7.3         - Patches from Jonathon Reinhart
                 - Fixed PCAP filter for PSH flag detection.
               - Patches from Christos Triantafyllidis

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.7.3         - Patches from Jonathon Reinhart
+                - Fixed PCAP filter for PSH flag detection.
+              - Patches from Christos Triantafyllidis
+                - Updated FSF address.
 0.7.2         - Patches from Paul Rogers (paul.rogers@flumps.org)
                 - Applied missing fixes from issue #16 - OpenBSD build
                   issues, reordering of headers, scoping DLT_LINUX_SLL for

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,9 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
-0.7.1         - Patches from Paul Rogers (paul.rogers@flumps.org)
-                - Fixed issue #2 - SIGHUP (reload) now listens for new
-                  sequences in the config file.
-                - Fixed issue #26 - knockd now fails if a malformed config
-                  file is read during SIGHUP (reload).
+0.7.2         - Patches from Paul Rogers (paul.rogers@flumps.org)
+                - Applied missing fixes from issue #16 - OpenBSD build
+                  issues, reordering of headers, scoping DLT_LINUX_SLL for
+                  Linux only, for -> while loop in sniff() cleanup.
 0.7           - Patches from Oswald Buddenhagen:
                 - Document the 'target' configuration directive.
                 - Merging OS-specific networking code to reduce LOCs and the

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
-0.7.4         - Patches from Michael GÃ¶hler
+0.7.5         - Added Greg Kuchyt's knock_add script but updated to be a
+                generic IPTables helper that also deletes rules
+0.7.4         - Patches from Michael Göhler
                 - Updated gitignore to include additional autoconf files.
                 - Updated Makefile to fix deprecated warning on CPPFLAG
 		- -D_BSD_SOURCE.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.7.4         - Patches from Michael Göhler
+                - Updated gitignore to include additional autoconf files.
+                - Updated Makefile to fix deprecated warning on CPPFLAG
+		- -D_BSD_SOURCE.
+              - Patches from Christos Triantafyllidis
+                - Updated FSF address.
 0.7.3         - Patches from Jonathon Reinhart
                 - Fixed PCAP filter for PSH flag detection.
               - Patches from Christos Triantafyllidis

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.7.1         - Patches from Paul Rogers (paul.rogers@flumps.org)
+                - Fixed issue #2 - SIGHUP (reload) now listens for new
+                  sequences in the config file.
+                - Fixed issue #26 - knockd now fails if a malformed config
+                  file is read during SIGHUP (reload).
 0.7           - Patches from Oswald Buddenhagen:
                 - Document the 'target' configuration directive.
                 - Merging OS-specific networking code to reduce LOCs and the

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ VERSION         DESCRIPTION
                 - Applied missing fixes from issue #16 - OpenBSD build
                   issues, reordering of headers, scoping DLT_LINUX_SLL for
                   Linux only, for -> while loop in sniff() cleanup.
+0.7.1         - Patches from Paul Rogers (paul.rogers@flumps.org)
+                - Fixed issue #2 - SIGHUP (reload) now listens for new
+                  sequences in the config file.
+                - Fixed issue #26 - knockd now fails if a malformed config
+                  file is read during SIGHUP (reload).
 0.7           - Patches from Oswald Buddenhagen:
                 - Document the 'target' configuration directive.
                 - Merging OS-specific networking code to reduce LOCs and the

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ man_MANS = doc/knock.1
 
 if BUILD_KNOCKD
 sbin_PROGRAMS = knockd
+dist_sbin_SCRIPTS = knock_helper_ipt.sh
 man_MANS += doc/knockd.1
 sysconf_DATA = knockd.conf
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-D_BSD_SOURCE
+AM_CPPFLAGS=-D_DEFAULT_SOURCE
 AM_CFLAGS=-g -Wall -pedantic -fno-exceptions
 
 bin_PROGRAMS = knock

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([knock], [0.7], [https://github.com/jvinet/knock/issues])
+AC_INIT([knock], [0.7.4], [https://github.com/jvinet/knock/issues])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign subdir-objects])
 
 AC_CONFIG_HEADER([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([knock], [0.7.4], [https://github.com/jvinet/knock/issues])
+AC_INIT([knock], [0.7.5], [https://github.com/jvinet/knock/issues])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign subdir-objects])
 
 AC_CONFIG_HEADER([config.h])

--- a/knockd.conf
+++ b/knockd.conf
@@ -13,3 +13,9 @@
 	command     = /usr/sbin/iptables -D INPUT -s %IP% -p tcp --dport 22 -j ACCEPT
 	tcpflags    = syn
 
+[openHTTPS]
+	sequence    = 12345,54321,24680,13579
+	seq_timeout = 5
+	command     = /usr/local/sbin/knock_add -i -c INPUT -p tcp -d 22 -f %IP%
+	tcpflags    = syn
+	

--- a/knockd.conf
+++ b/knockd.conf
@@ -16,6 +16,6 @@
 [openHTTPS]
 	sequence    = 12345,54321,24680,13579
 	seq_timeout = 5
-	command     = /usr/local/sbin/knock_add -i -c INPUT -p tcp -d 22 -f %IP%
+	command     = /usr/local/sbin/knock_add -i -c INPUT -p tcp -d 443 -f %IP%
 	tcpflags    = syn
 	

--- a/src/knock.c
+++ b/src/knock.c
@@ -13,10 +13,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, 
- *  USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <stdio.h>

--- a/src/knock_helper_ipt.sh
+++ b/src/knock_helper_ipt.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+
+# Original version to add non-duplicated rules by Greg Kuchyt (greg.kuchyt@gmail.com)
+# Updated to handle deletes and be generic by Paul Rogers (paul.rogers@flumps.org)
+
+SCRIPT_NAME=$(basename $0)
+
+AWK="/bin/awk"
+GREP="/bin/grep"
+IPTABLES="/sbin/iptables"
+SORT="/bin/sort"
+
+COMMENT_APP="Append "
+COMMENT_DEL="Delete "
+COMMENT_INS="Insert "
+COMMENT_DEFAULT="by knockd"
+
+IPT_CHAIN="INPUT"
+IPT_METHOD=""
+IPT_COMMENT=""
+IPT_SRC_IP=""
+IPT_DST_PORT=""
+IPT_PROTO="tcp"
+
+DRY_RUN=0
+SEEN=0
+VERBOSE=0
+
+usage() {
+	echo "Usage: $SCRIPT_NAME -a|-i|-x -f SRC_IP_ADDR -d DST_PORT [-p|-c|-m|-t|-h|-v]"
+	echo "Options:"
+	echo "-a|--append      Action: append a rule to NetFilter"
+	echo "-i|--insert      Action: insert a rule to NetFiler"
+	echo "-x|--delete      Action: delete a rule from NetFilter"
+	echo "-f|--srcaddr     The source IP address to be used"
+	echo "-d|--dstport     The destination port to be used in the rule"
+	echo "-p|--proto       The protocol that the rule applies to; default: $IPT_PROTO"
+	echo "-c|--chain       The NetFilter chain to apply the change to; default: $IPT_CHAIN"
+	echo "-m|--comment     Overide default comment text: '$COMMENT_DEFAULT'"
+	echo "-t|--test        Test run - don't actually perform an update to NetFilter"
+	echo "-h|--help        Print this informational screen and exit"
+	echo "-v|--verbose     Print verbose information about actions"
+}
+
+ARGS=$(getopt -o aixf:d:p:c:m::thv -l "append,insert,delete,srcaddr:,dstport:,proto:,chain:,comment::,test,help,verbose" -n $SCRIPT_NAME -- "$@")
+
+if [ $? -ne 0 ];
+then
+        echo "$SCRIPT_NAME - Error! Invalid arguments"
+        usage
+        exit 1
+fi
+
+eval set -- "$ARGS"
+
+while true; do
+        case "$1" in
+		-a|--append)
+			IPT_METHOD="-A"
+			shift;
+		;;
+		-x|--delete)
+			IPT_METHOD="-D"
+			shift;
+		;;
+		-i|--insert)
+			IPT_METHOD="-I"
+			shift;
+		;;
+		-f|--srcaddr)
+			IPT_SRC_IP=$2
+			shift 2;
+		;;
+		-d|--dstport)
+			IPT_DST_PORT=$2
+			shift 2;
+		;;
+		-p|--proto)
+			IPT_PROTO=$2
+			shift 2;
+		;;
+		-c|--chain)
+			IPT_CHAIN=$2
+			shift 2;
+		;;
+		-m|--comment)
+			case "$2" in
+				"")
+					IPT_COMMENT=$COMMENT_DEFAULT;
+					shift 2;;
+				*)
+					IPT_COMMENT=$2;
+					shift 2 ;;
+			esac
+		;;
+		-t|--test)
+			DRY_RUN=1
+                        shift;
+                ;;
+		-h|--help)
+			usage
+			shift;
+			exit
+		;;
+		-v|--verbose)
+			VERBOSE=1
+			shift;
+		;;
+                --)
+                        shift;
+                        break;
+                ;;
+        esac
+done
+
+# Begin sanity checks
+if [ -z "$IPT_SRC_IP" ]; then
+	echo "$SCRIPT_NAME - Error! Source IP address required"
+	usage
+	exit 1
+fi
+
+if [ -z "$IPT_DST_PORT" ]; then
+	echo "$SCRIPT_NAME - Error! Destination port required"
+	usage
+	exit 1
+fi
+
+if [ -z "$IPT_METHOD" ]; then
+	echo "$SCRIPT_NAME - Error! Valid action option not specified"
+fi
+
+case "$IPT_METHOD" in
+	-A)
+		IPT_COMMENT="$COMMENT_APP $IPT_COMMENT"
+		;;
+	-I)
+		IPT_COMMENT="$COMMENT_INS $IPT_COMMENT"
+		;;
+	-D)
+		IPT_COMMENT="$COMMENT_DEL $IPT_COMMENT"
+		;;
+esac
+
+if [ "$VERBOSE" -eq 1 ]; then
+	echo "$SCRIPT_NAME - Testing rule"
+	echo "$SCRIPT_NAME - action: $IPT_METHOD _ src: $IPT_SRC_IP _ dstport: $IPT_DST_PORT _ proto: $IPT_PROTO _ chain: $IPT_CHAIN _ comment: $IPT_COMMENT"
+fi
+
+COMMENT=""
+if [ -n "$IPT_COMMENT" ]; then
+	COMMENT="-m comment --comment '$IPT_COMMENT'"
+fi
+
+$IPTABLES -L $IPT_CHAIN &> /dev/null
+if [ 0 -ne "$?" ]; then
+	echo "$SCRIPT_NAME - Error: $IPT_CHAIN is not a valid NetFilter chain"
+	exit
+fi
+# End sanity checks
+
+# Dupe checking
+for IP in `$IPTABLES -n -L KNOCKD | $GREP ACCEPT | $AWK '{print $4}' | $SORT -u`;
+do
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "$SCRIPT_NAME - $IP"
+	fi
+
+	if [ "$IPT_SRC_IP" == "$IP" ]; then
+		SEEN=1
+	fi
+done
+
+if [ "$VERBOSE" -eq 1 ]; then
+	echo "$SCRIPT_NAME - Seen: $SEEN"
+fi
+
+
+if [ "$SEEN" -eq 0 ]; then
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "$SCRIPT_NAME - $IPT_COMMENT"
+		echo $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j ACCEPT $COMMENT
+	fi
+
+	if [ "$DRY_RUN" -eq 0 ]; then
+		eval $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j ACCEPT $COMMENT
+	fi
+fi

--- a/src/knock_helper_ipt.sh
+++ b/src/knock_helper_ipt.sh
@@ -21,6 +21,7 @@ IPT_COMMENT=""
 IPT_SRC_IP=""
 IPT_DST_PORT=""
 IPT_PROTO="tcp"
+IPT_RULE_TARGET="ACCEPT"
 
 DRY_RUN=0
 SEEN=0
@@ -160,7 +161,7 @@ fi
 # End sanity checks
 
 # Dupe checking
-for IP in `$IPTABLES -n -L KNOCKD | $GREP ACCEPT | $AWK '{print $4}' | $SORT -u`;
+for IP in `$IPTABLES -n -L $IPT_CHAIN | $GREP $IPT_RULE_TARGET | $AWK '{print $4}' | $SORT -u`;
 do
 	if [ "$VERBOSE" -eq 1 ]; then
 		echo "$SCRIPT_NAME - $IP"
@@ -179,10 +180,10 @@ fi
 if [ "$SEEN" -eq 0 ]; then
 	if [ "$VERBOSE" -eq 1 ]; then
 		echo "$SCRIPT_NAME - $IPT_COMMENT"
-		echo $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j ACCEPT $COMMENT
+		echo $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j $IPT_RULE_TARGET $COMMENT
 	fi
 
 	if [ "$DRY_RUN" -eq 0 ]; then
-		eval $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j ACCEPT $COMMENT
+		eval $IPTABLES $IPT_METHOD $IPT_CHAIN -s $IPT_SRC_IP -p $IPT_PROTO --dport $IPT_DST_PORT -j $IPT_RULE_TARGET $COMMENT
 	fi
 fi

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -915,7 +915,7 @@ void generate_pcap_filter()
 				}
 			}
 			if(door->flag_psh != DONT_CARE) {
-				bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-psh ", bufsize);
+				bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-push ", bufsize);
 				if(door->flag_psh == SET) {
 					bufsize = realloc_strcat(&buffer, "!= 0", bufsize);
 				}

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -48,7 +48,7 @@
 #include <errno.h>
 #include "list.h"
 
-static char version[] = "0.7.2";
+static char version[] = "0.7.3";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -32,12 +32,12 @@
 #include <sys/socket.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
-#include <netinet/if_ether.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <netinet/ip_icmp.h>
 #include <net/if.h>
+#include <netinet/if_ether.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/ioctl.h>
@@ -49,7 +49,7 @@
 #include <errno.h>
 #include "list.h"
 
-static char version[] = "0.7.1";
+static char version[] = "0.7.2";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */
@@ -220,9 +220,11 @@ int main(int argc, char **argv)
 		case DLT_EN10MB:
 			dprint("ethernet interface detected\n");
 			break;
+#ifdef __linux__
 		case DLT_LINUX_SLL:
 			dprint("ppp interface detected (linux \"cooked\" encapsulation)\n");
 			break;
+#endif
 		case DLT_RAW:
 			dprint("raw interface detected, no encapsulation\n");
 			break;
@@ -1376,7 +1378,7 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 	struct tcphdr* tcp = NULL;
 	struct udphdr* udp = NULL;
 	char proto[8];
-	/* TCP/IP data */	
+	/* TCP/IP data */
 	struct in_addr inaddr;
 	unsigned short sport, dport;
 	char srcIP[16], dstIP[16];
@@ -1450,24 +1452,38 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 			proto, srcIP, sport, dstIP, dport, hdr->len);
 
 	/* clean up expired/completed/failed attempts */
-	for(lp = attempts; lp; lp = lp->next) {
-		int nix = 0;
+	lp = attempts;
+	while(lp != NULL) {
+		int nix = 0; /* Clear flag */
+		PMList *lpnext = lp->next;
+
 		attempt = (knocker_t*)lp->data;
+
+		/* Check if the sequence has been completed */
 		if(attempt->stage >= attempt->door->seqcount) {
 			dprint("removing successful knock attempt (%s)\n", attempt->src);
 			nix = 1;
 		}
+
+		/* Signed integer overflow check.
+		   If we received more than 32767 packets the sign will be negative*/
 		if(attempt->stage < 0) {
 			dprint("removing failed knock attempt (%s)\n", attempt->src);
 			nix = 1;
 		}
+
+		/* Check if timeout has been reached */
 		if(!nix && (pkt_secs - attempt->seq_start) >= attempt->door->seq_timeout) {
+
+			/* Do we know the hostname? */
 			if(attempt->srchost) {
+				/* Log the hostname */
 				vprint("%s (%s): %s: sequence timeout (stage %d)\n", attempt->src, attempt->srchost,
 						attempt->door->name, attempt->stage);
 				logprint("%s (%s): %s: sequence timeout (stage %d)\n", attempt->src, attempt->srchost,
 						attempt->door->name, attempt->stage);
 			} else {
+				/* Log the IP */
 				vprint("%s: %s: sequence timeout (stage %d)\n", attempt->src,
 						attempt->door->name, attempt->stage);
 				logprint("%s: %s: sequence timeout (stage %d)\n", attempt->src,
@@ -1475,17 +1491,23 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 			}
 			nix = 1;
 		}
+
+		/* If clear flag is set */
 		if(nix) {
-			knocker_t *k = (knocker_t*)lp->data;
 			/* splice this entry out of the list */
 			if(lp->prev) lp->prev->next = lp->next;
 			if(lp->next) lp->next->prev = lp->prev;
+			/* If lp is the only element of the list then empty the list */
 			if(lp == attempts) attempts = NULL;
 			lp->prev = lp->next = NULL;
-			free(k->srchost);
+			if (attempt->srchost) {
+				free(attempt->srchost);
+				attempt->srchost = NULL;
+			}
 			list_free(lp);
-			continue;
 		}
+
+		lp = lpnext;
 	}
 
 	attempt = NULL;

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -13,10 +13,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
- *  USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <stdio.h>

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -48,7 +48,7 @@
 #include <errno.h>
 #include "list.h"
 
-static char version[] = "0.7.3";
+static char version[] = "0.7.4";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -386,19 +386,29 @@ void reload(int signum)
 	}
 	list_free(doors);
 
-	parseconfig(o_cfg);
+	vprint("Closing log file: %s\n", o_logfile);
+	logprint("Closing log file: %s\n", o_logfile);
 
-	vprint("Closing and re-opening log file: %s\n", o_logfile);
-	logprint("Closing and re-opening log file: %s\n", o_logfile);
-
-	/* close and re-open the log file */
+	/* close the log file */
 	if(logfd) {
 		fclose(logfd);
 	}
+
+	if(parseconfig(o_cfg)) {
+		exit(1);
+	}
+
+	vprint("Re-opening log file: %s\n", o_logfile);
+	logprint("Re-opening log file: %s\n", o_logfile);
+
+	/* re-open the log file */
 	logfd = fopen(o_logfile, "a");
 	if(logfd == NULL) {
 		perror("warning: cannot open logfile");
 	}
+
+	/* Fix issue #2 by regenerating the PCAP filter post config file re-read */
+	generate_pcap_filter();
 
 	return;
 }

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -49,7 +49,7 @@
 #include <errno.h>
 #include "list.h"
 
-static char version[] = "0.7";
+static char version[] = "0.7.1";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */

--- a/src/list.c
+++ b/src/list.c
@@ -13,10 +13,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, 
- *  USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <stdlib.h>

--- a/src/list.h
+++ b/src/list.h
@@ -13,10 +13,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, 
- *  USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 #ifndef _PAC_LIST_H
 #define _PAC_LIST_H


### PR DESCRIPTION
#26 - reload now detects a configuration file error and exits instead of running without any knock sequences configured.
#2 - regenerates the PCAP filter after a successful reload of the configuration file