### PR TITLE
Add support of ipv6 on client and server (asked by issue #8)

### DIFF
--- a/doc/knock.1.in
+++ b/doc/knock.1.in
@@ -21,8 +21,11 @@ where a router mistakes your stream of SYN packets as a port scan and blocks
 them.  If the packet rate is slowed with \-\-delay, then the router should let
 the packets through.
 .TP
-.B "\-i, \-\-ip <version>"
-IP version to be used (4 or 6). If not defined, use what is returned by DNS solving.
+.B "\-4, \-\-ipv4 <version>"
+Force usage of IPv4.
+.TP
+.B "\-6, \-\-ipv6 <version>"
+Force usage of IPv6.
 .TP
 .B "\-v, \-\-verbose"
 Output verbose status messages.

--- a/doc/knock.1.in
+++ b/doc/knock.1.in
@@ -21,6 +21,9 @@ where a router mistakes your stream of SYN packets as a port scan and blocks
 them.  If the packet rate is slowed with \-\-delay, then the router should let
 the packets through.
 .TP
+.B "\-i, \-\-ip <version>"
+IP version to be used (4 or 6). If not defined, use what is returned by DNS solving.
+.TP
 .B "\-v, \-\-verbose"
 Output verbose status messages.
 .TP

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -31,6 +31,9 @@ Output debugging messages.
 Lookup DNS names for log entries. This may be a security risk! See section
 \fBSECURITY NOTES\fP.
 .TP
+.B "\-4, \-\-only-ip-v4"
+Ignore packets from IPv6 and handle only IPv4.
+.TP
 .B "\-v, \-\-verbose"
 Output verbose status messages.
 .TP

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -213,7 +213,9 @@ knocker's IP address.  The \fBCommand\fP directive is an alias for
 Specify the command to be executed when a client makes the correct
 port-knock with IPv6.  All instances of \fB%IP%\fP will be replaced with the
 knocker's IP address.  The \fBCommand_6\fP directive is an alias for
-\fBStart_Command_6\fP.
+\fBStart_Command_6\fP. If not present it will automatically fallback onto
+the same IPV4 \fBStart_Command\fP value. You can use empty value to force
+doing nothing.
 .TP
 .B "Cmd_Timeout = <timeout>"
 Time to wait (in seconds) between \fBStart_Command\fP and \fBStop_Command\fP.
@@ -228,6 +230,9 @@ be replaced with the knocker's IP address.  This directive is optional.
 Specify the command to be executed when \fBCmd_Timeout\fP seconds have passed 
 since \fBStart_Command_6\fP has been executed.  All instances of \fB%IP%\fP will
 be replaced with the knocker's IP address.  This directive is optional.
+If not present it will automatically fallback onto the same IPV4 
+\fBStop_Command\fP value. You can use empty value to force
+doing nothing.
 .SH SECURITY NOTES 
 Using the \fB-l\fP or \fB--lookup\fP commandline option to resolve DNS names
 for log entries may be a security risk!  An attacker may find out the first port

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -135,10 +135,10 @@ of the two protocols.
 	seq_timeout        = 15
 	tcpflags           = fin,!ack
 	start_command      = /usr/sbin/iptables \-A INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
-	start_command6     = /usr/sbin/ip6tables \-A INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	start_command_6    = /usr/sbin/ip6tables \-A INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
 	cmd_timeout        = 5
 	stop_command       = /usr/sbin/iptables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
-	stop_command6      = /usr/sbin/ip6tables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	stop_command_6     = /usr/sbin/ip6tables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
 	
 .fi
 .RE
@@ -205,9 +205,15 @@ etherwake to send the host a WOL packet.
 .TP
 .B "Start_Command = <command>"
 Specify the command to be executed when a client makes the correct
-port-knock.  All instances of \fB%IP%\fP will be replaced with the
+port-knock with IPv4.  All instances of \fB%IP%\fP will be replaced with the
 knocker's IP address.  The \fBCommand\fP directive is an alias for
 \fBStart_Command\fP.
+.TP
+.B "Start_Command_6 = <command>"
+Specify the command to be executed when a client makes the correct
+port-knock with IPv6.  All instances of \fB%IP%\fP will be replaced with the
+knocker's IP address.  The \fBCommand_6\fP directive is an alias for
+\fBStart_Command_6\fP.
 .TP
 .B "Cmd_Timeout = <timeout>"
 Time to wait (in seconds) between \fBStart_Command\fP and \fBStop_Command\fP.
@@ -216,6 +222,11 @@ This directive is optional, only required if \fBStop_Command\fP is used.
 .B "Stop_Command = <command>"
 Specify the command to be executed when \fBCmd_Timeout\fP seconds have passed 
 since \fBStart_Command\fP has been executed.  All instances of \fB%IP%\fP will
+be replaced with the knocker's IP address.  This directive is optional.
+.TP
+.B "Stop_Command_6 = <command>"
+Specify the command to be executed when \fBCmd_Timeout\fP seconds have passed 
+since \fBStart_Command_6\fP has been executed.  All instances of \fB%IP%\fP will
 be replaced with the knocker's IP address.  This directive is optional.
 .SH SECURITY NOTES 
 Using the \fB-l\fP or \fB--lookup\fP commandline option to resolve DNS names

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -117,6 +117,27 @@ sniffing the network).
 	stop_command       = /usr/sbin/iptables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
 	
 .fi
+.TP
+.SH Example #4:
+.RS
+Example to support IPv4 and IPv6. You can provide a dedicated command for each
+of the two protocols.
+
+.nf
+[options]
+	logfile = /var/log/knockd.log
+
+[opencloseSMTP]
+	one_time_sequences = /etc/knockd/smtp_sequences
+	seq_timeout        = 15
+	tcpflags           = fin,!ack
+	start_command      = /usr/sbin/iptables \-A INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	start_command6     = /usr/sbin/ip6tables \-A INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	cmd_timeout        = 5
+	stop_command       = /usr/sbin/iptables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	stop_command6      = /usr/sbin/ip6tables \-D INPUT \-s %IP% \-p tcp \-\-dport 25 \-j ACCEPT
+	
+.fi
 .RE
 .SH CONFIGURATION: GLOBAL DIRECTIVES
 .TP

--- a/src/knock.c
+++ b/src/knock.c
@@ -204,6 +204,7 @@ void usage() {
 	printf("options:\n");
 	printf("  -u, --udp            make all ports hits use UDP (default is TCP)\n");
 	printf("  -d, --delay <t>      wait <t> milliseconds between port hits\n");
+	printf("  -i, --ip <version>   IP version to be used (4 or 6)\n");
 	printf("  -v, --verbose        be verbose\n");
 	printf("  -V, --version        display version\n");
 	printf("  -h, --help           this help\n");

--- a/src/knock.c
+++ b/src/knock.c
@@ -54,21 +54,6 @@ int o_udp     = 0;
 int o_delay   = 0;
 int o_ip      = IP_DEFAULT;
 
-int txt_to_ip_version(const char * value)
-{
-	int n = atoi(value);
-	
-	if (n == 4)
-	{
-		return IP_V4;
-	} else if (n == 6) {
-		return IP_V6;
-	} else {
-		fprintf(stderr,"Invalid IP protocol version %d, should be 4 or 6 !",n);
-		exit(1);
-	}
-}
-
 int main(int argc, char** argv)
 {
 	int sd;
@@ -85,11 +70,12 @@ int main(int argc, char** argv)
 		{"delay",     required_argument, 0, 'd'},
 		{"help",      no_argument,       0, 'h'},
 		{"version",   no_argument,       0, 'V'},
-		{"ip",        required_argument, 0, 'i'},
+		{"ipv4",      no_argument,       0, '4'},
+		{"ipv6",      no_argument,       0, '6'},
 		{0, 0, 0, 0}
 	};
 
-	while((opt = getopt_long(argc, argv, "vud:hVi:", opts, &optidx))) {
+	while((opt = getopt_long(argc, argv, "vud:hV46", opts, &optidx))) {
 		if(opt < 0) {
 			break;
 		}
@@ -99,7 +85,8 @@ int main(int argc, char** argv)
 			case 'u': o_udp = 1; break;
 			case 'd': o_delay = (int)atoi(optarg); break;
 			case 'V': ver();
-			case 'i': o_ip = txt_to_ip_version(optarg); break;
+			case '4': o_ip = IP_V4; break;
+			case '6': o_ip = IP_V6; break;
 			case 'h': /* fallthrough */
 			default: usage();
 		}
@@ -204,7 +191,8 @@ void usage() {
 	printf("options:\n");
 	printf("  -u, --udp            make all ports hits use UDP (default is TCP)\n");
 	printf("  -d, --delay <t>      wait <t> milliseconds between port hits\n");
-	printf("  -i, --ip <version>   IP version to be used (4 or 6)\n");
+	printf("  -4, --ipv4           Force usage of IPv4\n");
+	printf("  -6, --ipv6           Force usage of IPv6\n");
 	printf("  -v, --verbose        be verbose\n");
 	printf("  -V, --version        display version\n");
 	printf("  -h, --help           this help\n");

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -293,7 +293,6 @@ int main(int argc, char **argv)
 						freeifaddrs(ifaddr);
 						cleanup(1);
 					} else {
-						printf("\n\n%s\n\n",myip->value);
 						char * ptr = strchr(myip->value,'%');
 						if (ptr != NULL)
 							*ptr = '\0';
@@ -1013,7 +1012,7 @@ void generate_pcap_filter()
 			if(tcp_present) {
 				if(door->flag_fin != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x01 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-fin ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-fin ", bufsize);
 					if(door->flag_fin == SET) {
@@ -1025,7 +1024,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_syn != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x02 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-syn ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-syn ", bufsize);
 					if(door->flag_syn == SET) {
@@ -1037,7 +1036,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_rst != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x04 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-rst ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-rst ", bufsize);
 					if(door->flag_rst == SET) {
@@ -1049,7 +1048,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_psh != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x08 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-push ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-push ", bufsize);
 					if(door->flag_psh == SET) {
@@ -1061,7 +1060,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_ack != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x10 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-ack ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-ack ", bufsize);
 					if(door->flag_ack == SET) {
@@ -1073,7 +1072,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_urg != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x20 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-urg ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-urg ", bufsize);
 					if(door->flag_urg == SET) {
@@ -1158,22 +1157,23 @@ void generate_pcap_filter()
 	 */
 	if(modified_filters) {
 		/* iterate over all doors */
+		int first = 1;
 		for(lp = doors; lp; lp = lp->next) {
 			door = (opendoor_t*)lp->data;
 			for (ipv6 = 0 ; ipv6 <= 1 ; ipv6++)
 			{
+				if (first)
+					first = 0;
+				else
+					bufsize = realloc_strcat(&buffer, " or ", bufsize);
 				if (ipv6 && o_skipIpV6)
 					continue;
 				if (ipv6)
 					bufsize = realloc_strcat(&buffer, door->pcap_filter_expv6, bufsize);
 				else
 					bufsize = realloc_strcat(&buffer, door->pcap_filter_exp, bufsize);
-				bufsize = realloc_strcat(&buffer, " or ", bufsize);
 			}
 		}
-		
-		//track to avoid to remove last or.... to be improved
-		bufsize = realloc_strcat(&buffer, "(0==1)", bufsize);
 		
 		//dprint("FULL : %s\n",buffer);
 

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1464,6 +1464,14 @@ void process_attempt(knocker_t *attempt)
 	{
 		start_command = attempt->door->start_command6;
 		stop_command = attempt->door->stop_command6;
+		
+		//make default fallback to same than ipv4 if v6 command is not set.
+		if (start_command == NULL) {
+			start_command = attempt->door->start_command;
+		}
+		if (stop_command == NULL) {
+			stop_command = attempt->door->stop_command;
+		}
 	} else {
 		start_command = attempt->door->start_command;
 		stop_command = attempt->door->stop_command;

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -293,6 +293,7 @@ int main(int argc, char **argv)
 						freeifaddrs(ifaddr);
 						cleanup(1);
 					} else {
+						printf("\n\n%s\n\n",myip->value);
 						char * ptr = strchr(myip->value,'%');
 						if (ptr != NULL)
 							*ptr = '\0';
@@ -698,14 +699,14 @@ int parseconfig(char *configfile)
 						}
 						strcpy(door->start_command, ptr);
 						dprint("config: %s: start_command: %s\n", door->name, door->start_command);
-					} else if(!strcmp(key, "START_COMMAND6") || !strcmp(key, "COMMAND6")) {
+					} else if(!strcmp(key, "START_COMMAND_6") || !strcmp(key, "COMMAND_6")) {
 						door->start_command6 = malloc(sizeof(char) * (strlen(ptr)+1));
 						if(door->start_command6 == NULL) {
 							perror("malloc");
 							exit(1);
 						}
 						strcpy(door->start_command6, ptr);
-						dprint("config: %s: start_command6: %s\n", door->name, door->start_command6);
+						dprint("config: %s: start_command_6: %s\n", door->name, door->start_command6);
 					} else if(!strcmp(key, "CMD_TIMEOUT")) {
 						door->cmd_timeout = (time_t)atoi(ptr);
 						dprint("config: %s: cmd_timeout: %d\n", door->name, door->cmd_timeout);
@@ -717,14 +718,14 @@ int parseconfig(char *configfile)
 						}
 						strcpy(door->stop_command, ptr);
 						dprint("config: %s: stop_command: %s\n", door->name, door->stop_command);
-					} else if(!strcmp(key, "STOP_COMMAND6")) {
+					} else if(!strcmp(key, "STOP_COMMAND_6")) {
 						door->stop_command6 = malloc(sizeof(char) * (strlen(ptr)+1));
 						if(door->stop_command6 == NULL) {
 							perror("malloc");
 							exit(1);
 						}
 						strcpy(door->stop_command6, ptr);
-						dprint("config: %s: stop_command6: %s\n", door->name, door->stop_command6);
+						dprint("config: %s: stop_command_6: %s\n", door->name, door->stop_command6);
 					} else if(!strcmp(key, "TCPFLAGS")) {
 						char *flag;
 						strtoupper(ptr);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1559,7 +1559,8 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 	char proto[8];
 	/* TCP/IP data */
 	struct in_addr inaddr;
-	unsigned short sport, dport;
+	unsigned short sport = 0;
+	unsigned short dport = 0;
 	char srcIP[64], dstIP[64];
 	/* timestamp */
 	time_t pkt_secs = hdr->ts.tv_sec;
@@ -1569,8 +1570,8 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 	PMList *lp;
 	knocker_t *attempt = NULL;
 	PMList *found_attempts = NULL;
-	int ipProto;
-	int fromIpV6;
+	int ipProto = 0;
+	int fromIpV6 = 0;
 
 	if(lltype == DLT_EN10MB) {
 		eth = (struct ether_header*)packet;

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1012,7 +1012,7 @@ void generate_pcap_filter()
 			if(tcp_present) {
 				if(door->flag_fin != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x01 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-fin ", bufsize);
 					if(door->flag_fin == SET) {
@@ -1024,7 +1024,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_syn != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x02 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-syn ", bufsize);
 					if(door->flag_syn == SET) {
@@ -1036,7 +1036,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_rst != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x04 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-rst ", bufsize);
 					if(door->flag_rst == SET) {
@@ -1048,7 +1048,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_psh != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x08 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-push ", bufsize);
 					if(door->flag_psh == SET) {
@@ -1060,7 +1060,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_ack != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x10 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-ack ", bufsize);
 					if(door->flag_ack == SET) {
@@ -1072,7 +1072,7 @@ void generate_pcap_filter()
 				}
 				if(door->flag_urg != DONT_CARE) {
 					if (ipv6)
-						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x17 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
+						bufsize = realloc_strcat(&buffer, " and ip6[13+40] & 0x20 ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
 					else
 						bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-urg ", bufsize);
 					if(door->flag_urg == SET) {

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -426,15 +426,15 @@ void cleanup(int signum)
 	if(o_daemon) {
 		unlink(o_pidfile);
 	}
-
+	
 	if(myips) {
-//TODO find double free cause
-// 		while(myips) {
-// 			if(myip->value)
-// 				free(myip->value);
-// 			myips = myip->next;
-// 			free(myip);
-// 		}
+		while(myips) {
+			if(myip->value)
+				free(myip->value);
+			myips = myip->next;
+			free(myip);
+			myip = myips;
+		}
 	}
 
 	exit(signum);
@@ -1655,8 +1655,7 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 		inet_ntop(AF_INET6, &ip6->ip6_src, srcIP,sizeof(srcIP));
 		inet_ntop(AF_INET6, &ip6->ip6_dst, dstIP,sizeof(srcIP));
 	} else {
-		//TODO comment
-		dprint("Invalid protocol (not ipv4 or ipv6) !");
+		//dprint("Invalid protocol (not ipv4 or ipv6) !");
 		return;
 	}
 
@@ -1775,10 +1774,14 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 					attempt->fromIpV6 = fromIpV6;
 					strcpy(attempt->src, srcIP);
 					/* try a reverse lookup if enabled  */
-					//TODO support ipv6
-					if (o_lookup && fromIpV6 == 0) {
-						inaddr.s_addr = ip->ip_src.s_addr;
-						he = gethostbyaddr((void *)&inaddr, sizeof(inaddr), AF_INET);
+					if (o_lookup) {
+						if (fromIpV6 == 0)
+						{
+							inaddr.s_addr = ip->ip_src.s_addr;
+							he = gethostbyaddr((void *)&inaddr, sizeof(inaddr), AF_INET);
+						} else {
+							he = gethostbyaddr((void *)&ip6->ip6_src, sizeof(ip6->ip6_src), AF_INET6);
+						}
 						if(he) {
 							attempt->srchost = strdup(he->h_name);
 						}


### PR DESCRIPTION
Hi,
I was looking for ipv6 support for one of my server so I implemented it. It should close #8 .

The patch contains changes to knock client and to knockd server  to support v4/v6.

Client
--------

About the client, there is a choice to be done for the default mode. I currently use the default IP returned by DNS resolving, which could be ipv6. Then you can choose to force v4/v6 by using option `-4` / `--ipv4` or `-6` / `--ipv6`.

The user can give a host name or an ipv6 like with v4 mode.

To be seen if it is not better to keep v4 only by default, can be patched by changing the default value of `o_ip` line 55 in knock.c.

If we keep the default ip returned by the DNS maybe we should add a message to tell the user which ip we selected, otherwise someone might get stuck not knowing that he knock on ipv6 instead of v4.

Server
---------

The server by default extract all the IPs from the selected interface (v6 and v4). Then it builds the pcap rules for all those ips. We can disable v6 support by using options `-4` / `--only-ip-v4`.

Again to be seen if we do not make the invert and require enabling of ipv6 instead of enabled by default.

There is a trick for the pcap rules: tcp flags (SYN, FIN...)  are not supported for ipv6 so I had to hardcode the extraction. Eg for FIN : 

```c
if (ipv6)
		bufsize = realloc_strcat(&buffer, " and ip6[13+40] & tcp-fin ", bufsize);//using directly mask as pcap didn't yet support flags for IPv6
else
		bufsize = realloc_strcat(&buffer, " and tcp[tcpflags] & tcp-fin ", bufsize);
```

Local address
------------------

IPv6 link often setup a local IP on every link, in the current patch I also handle the knocking on this local IP, if you want to disable this feature import my branch no-local there is a commit to get same behavior than the debian proposal from issue #8.

One thing on this, don't know why when requesting the list of IP of the selected interface the local link is returnes with an extra string : a0a6:sds4...:44%enp0s3. So to proceed I remove what is after %.

About IPv6 packet encapsulation
--------------------------------------------

IPv6 can handle extended header for some usage. This is not handled by this patch, I considered the TCP/UDP header directly after the UDP packet. The other cases are detected and ignored.

Server rules
----------------

About the rules, we might want to call iptables to open access but ipv6 is handled by `ip6tables` instead of `iptables`. In order to proceed we provide two separate commands, one for ipv4 and one for ipv6 in the config file : 

```ini
[options]
        logfile = /var/log/knockd.log

[openSSH]
        sequence    = 7000,8000,9000
        seq_timeout = 5
        command     = /bin/echo OPEN %IP% V4
        command_6   = /bin/echo OPEN %IP% V6
        tcpflags    = syn

[closeSSH]
        sequence    = 9000,8000,7000
        seq_timeout = 5
        command     = /bin/echo CLOSE %IP% V4
        command_6   = /bin/echo CLOSE %IP% V6
        tcpflags    = syn
```

Same for `start_command_6` and `stop_command_6`.

New dependency
-----------------------

The code now depend on : 

```c
#include <netinet/ip6.h>
```

Doc
-----

I also updated the documentation (--help and manpages) accordingly and add an ipv6 config file example for the server.

Bugfix
--------

There was a double free corruption in knockd cleanup() function when the interface has multiple IPs.
 
Validation
-------------

I validated the full chain by makeing port knocking on ipv4 and v6 on one of my server using tcp-syn.
  
  
  
  