### PR TITLE
Added a new --interface option to knock

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,12 @@ endif
 
 dist_doc_DATA = README.md TODO ChangeLog COPYING
 
-knock_SOURCES = src/knock.c
+knock_SOURCES = src/knock.c src/interface.h
+if USE_GETIFADDRS
+knock_SOURCES += src/interface_getifaddrs.c
+else
+knock_SOURCES += src/interface_ioctl.c
+endif
 knockd_SOURCES = src/knockd.c src/list.c src/list.h src/knock_helper_ipt.sh
 
 %.1: %.1.in

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([knock], [0.7.8], [https://github.com/jvinet/knock/issues])
+AC_INIT([knock], [0.7.9], [https://github.com/jvinet/knock/issues])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign subdir-objects])
 
 AC_CONFIG_HEADER([config.h])
@@ -10,12 +10,22 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_ARG_ENABLE([knockd],
   [AS_HELP_STRING([--disable-knockd], [Disable building knockd (requires libpcap) @<:@default=enabled@:>@])])
 
+AC_ARG_ENABLE([getifaddrs],
+  [AS_HELP_STRING([--disable-getifaddrs], [Disable using getifaddrs from glib @<:@default=enabled@:>@])])
+
 AS_IF([test "x$enable_knockd" != "xno"], [
   AC_CHECK_LIB([pcap], [pcap_dispatch], ,
     [AC_MSG_ERROR([you need the libpcap library to build knockd])])
 ])
 
+AS_IF([test "x$enable_getifaddrs" != "xno"], [
+  AC_CHECK_FUNC([getifaddrs],
+    [AC_DEFINE([HAVE_GETIFADDRS],[],[Use getifaddrs function])],
+    [AC_MSG_ERROR([can not find getifaddrs function.])])
+])
+
 AM_CONDITIONAL([BUILD_KNOCKD], [test "x$enable_knockd" != "xno"])
+AM_CONDITIONAL([USE_GETIFADDRS], [test "x$enable_getifaddrs" != "xno"])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/doc/knock.1.in
+++ b/doc/knock.1.in
@@ -21,7 +21,7 @@ where a router mistakes your stream of SYN packets as a port scan and blocks
 them.  If the packet rate is slowed with \-\-delay, then the router should let
 the packets through.
 .TP
-.B "\-i <n>, \-\-delay <n>"
+.B "\-i <n>, \-\-interface <n>"
 Use network interface <n> for knocks, like eth0. This option can be useful
 when a system has more than one network interface with different gateways
 (multihomed).

--- a/doc/knock.1.in
+++ b/doc/knock.1.in
@@ -21,6 +21,11 @@ where a router mistakes your stream of SYN packets as a port scan and blocks
 them.  If the packet rate is slowed with \-\-delay, then the router should let
 the packets through.
 .TP
+.B "\-i <n>, \-\-delay <n>"
+Use network interface <n> for knocks, like eth0. This option can be useful
+when a system has more than one network interface with different gateways
+(multihomed).
+.TP
 .B "\-v, \-\-verbose"
 Output verbose status messages.
 .TP

--- a/src/interface.h
+++ b/src/interface.h
@@ -1,0 +1,7 @@
+#include <netinet/in.h>
+#include <stdbool.h>
+
+#ifndef MY_INTERFACE
+#define MY_INTERFACE
+bool get_interface_addr4(const char *if_name,struct in_addr *if_addr);
+#endif // MY_INTERFACE

--- a/src/interface_getifaddrs.c
+++ b/src/interface_getifaddrs.c
@@ -1,0 +1,34 @@
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdbool.h>
+#include "interface.h"
+
+bool get_interface_addr4(const char *if_name,struct in_addr *if_addr) {
+	struct ifaddrs *addrs=NULL,*tmp=NULL;
+	bool found=false;
+	getifaddrs(&addrs);
+	tmp=addrs;
+	while(tmp) {
+		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
+#ifdef __clang__
+			#pragma clang diagnostic push
+			#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+			struct sockaddr_in *addr_in = (struct sockaddr_in *)tmp->ifa_addr;
+#ifdef __clang__
+			#pragma clang diagnostic pop
+#endif
+			if (strcmp(if_name,tmp->ifa_name) == 0 ) {
+				if_addr->s_addr = addr_in->sin_addr.s_addr;
+				found=true;
+				break;
+			}
+		}
+		tmp = tmp->ifa_next;
+	}
+	freeifaddrs(addrs);
+	return found;
+}

--- a/src/interface_ioctl.c
+++ b/src/interface_ioctl.c
@@ -1,0 +1,41 @@
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include "interface.h"
+#include <errno.h>
+
+bool get_interface_addr4(const char *if_name,struct in_addr *if_addr) {
+	struct ifreq ifr;
+	int s;
+
+	s = socket(AF_INET, SOCK_DGRAM, 0);
+	if(s < 0) {
+		printf("%s is %d\n",strerror(errno),s);
+		return(false);
+	}
+
+	memset(ifr.ifr_name, 0, sizeof(ifr.ifr_name));
+	strncpy(ifr.ifr_name, if_name, sizeof(ifr.ifr_name)-1);
+	printf("%s\n",ifr.ifr_name);
+	ifr.ifr_name[sizeof(ifr.ifr_name)-1] = '\0';
+	if(ioctl(s, SIOCGIFADDR, &ifr)==-1) {
+		close(s);
+		return(false);
+	}
+	close(s);
+#ifdef __clang__
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+	struct sockaddr_in *addr_in = (struct sockaddr_in *)&ifr.ifr_addr;
+#ifdef __clang__
+		#pragma clang diagnostic pop
+#endif
+	if_addr->s_addr = addr_in->sin_addr.s_addr;
+	return(true);
+}


### PR DESCRIPTION
Hi,
Recently I needed to knock a server from a client with multiple network interfaces which had different gateways, and since `knock` did not have a way to choose an interface, I added one.
Hopefully, It is useful to others.

I implemented two ways to find the ip address of an interface. One, using `ioctl` which is the way `knockd` also uses, and the other one uses glibc [`getifaddrs`](https://linux.die.net/man/3/getifaddrs). The idea is to refactor the code for finding the interface's address; in both `knock` and `knockd`. There is an option in `configure` (namely `--disable-getifaddrs`) to choose between each way.

Manual pages have also been changed, accordingly.

