### PR TITLE
Option: Don't fail on duplicate knocks

### DIFF
--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -133,6 +133,10 @@ Pidfile to use when in daemon mode, default: /var/run/knockd.pid.
 .B "Interface = <interface_name>"
 Network interface to listen on. Only its name has to be given, not the path to
 the device (eg, "eth0" and not "/dev/eth0"). Default: eth0.
+.TP
+.B "AllowDuplictes"
+If specified, duplicate knocks of already correctly knocked ports will not lead
+to the abortion of the knock sequence. Useful e.g. for browser-based knocking.
 .SH CONFIGURATION: KNOCK/EVENT DIRECTIVES
 .TP
 .B "Sequence = <port1>[:<tcp|udp>],<port2>[:<tcp|udp>][,<port3>[:<tcp|udp>] ...]"

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -134,7 +134,7 @@ Pidfile to use when in daemon mode, default: /var/run/knockd.pid.
 Network interface to listen on. Only its name has to be given, not the path to
 the device (eg, "eth0" and not "/dev/eth0"). Default: eth0.
 .TP
-.B "AllowDuplictes"
+.B "AllowDuplicates"
 If specified, duplicate knocks of already correctly knocked ports will not lead
 to the abortion of the knock sequence. Useful e.g. for browser-based knocking.
 .SH CONFIGURATION: KNOCK/EVENT DIRECTIVES

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1603,12 +1603,12 @@ void process_attempt(knocker_t *attempt)
 
 /**
  * Depending on configuration, duplicates of ports already knocked in a sequence
- * may be duplicated (e.g. if a browser always sends 2 SYN-packets)
+ * may be ignored (e.g. if a browser always sends 2 SYN-packets)
  */
-int already_matched(knocker_t * attempt, unsigned short dport, uint8_t proto) {
-	if (o_duplicate) {
-		for (int i = 0; i < attempt->stage; ++i) {
-			if (dport == attempt->door->sequence[i]
+int already_matched(knocker_t* attempt, unsigned short dport, uint8_t proto) {
+	if(o_duplicate) {
+		for(int i = 0; i < attempt->stage; ++i) {
+			if(dport == attempt->door->sequence[i]
 				&& proto == attempt->door->protocol[i]) {
 				return 1;
 			}
@@ -1821,6 +1821,7 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 		found_attempts = list_add(found_attempts, NULL);
 	}
 
+
 	for(found_attempt = found_attempts; found_attempt != NULL; found_attempt = found_attempt->next) {
 		attempt = (knocker_t*)found_attempt->data;
 		found_attempt->data = NULL;
@@ -1830,6 +1831,7 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 			if(flagsmatch && ip_proto == attempt->door->protocol[attempt->stage] &&
 					dport == attempt->door->sequence[attempt->stage]) {
 				process_attempt(attempt);
+
 			} else if(flagsmatch == 0 || already_matched(attempt, dport, ip->ip_p)) {
 				/* TCP flags didn't match -- just ignore this packet, don't
 				 * invalidate the knock.

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -152,6 +152,7 @@ int  o_verbose   = 0;
 int  o_debug     = 0;
 int  o_daemon    = 0;
 int  o_lookup    = 0;
+int  o_duplicate = 0;
 char o_int[32]           = "";		/* default (eth0) is set after parseconfig() */
 char o_cfg[PATH_MAX]     = "/etc/knockd.conf";
 char o_pidfile[PATH_MAX] = "/var/run/knockd.pid";
@@ -611,6 +612,9 @@ int parseconfig(char *configfile)
 				if(!strcmp(key, "USESYSLOG")) {
 					o_usesyslog = 1;
 					dprint("config: usesyslog\n");
+				} else if(!strcmp(key, "ALLOWDUPLICATES")) {
+					o_duplicate = 1;
+					dprint("config: allowduplicates set\n");
 				} else {
 					fprintf(stderr, "config: line %d: syntax error\n", linenum);
 					return(1);
@@ -1451,10 +1455,12 @@ void process_attempt(knocker_t *attempt)
  * may be duplicated (e.g. if a browser always sends 2 SYN-packets)
  */
 int already_matched(knocker_t * attempt, unsigned short dport, uint8_t proto) {
-	for (int i = 0; i < attempt->stage; ++i) {
-		if (dport == attempt->door->sequence[i]
-			&& proto == attempt->door->protocol[i]) {
-			return 1;
+	if (o_duplicate) {
+		for (int i = 0; i < attempt->stage; ++i) {
+			if (dport == attempt->door->sequence[i]
+				&& proto == attempt->door->protocol[i]) {
+				return 1;
+			}
 		}
 	}
 	return 0;


### PR DESCRIPTION
This adds the AllowDuplicates configuration directive. If specified, knockd will ignore duplicates of packets that already matched the knock sequence. This allows for browser-based knocking.