### PR TITLE
Fix multiple memory safety issues

### DIFF
--- a/src/knock.c
+++ b/src/knock.c
@@ -109,6 +109,7 @@ int main(int argc, char** argv)
 		} else {
 			port = atoi(arg);
 		}
+		free(arg);
 
 		if(o_udp || proto == PROTO_UDP) {
 			sd = socket(PF_INET, SOCK_DGRAM, 0);

--- a/src/knock.c
+++ b/src/knock.c
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
 	}
 	for(; optind < argc; optind++) {
 		unsigned short port, proto = PROTO_TCP;
-		char *ptr, *arg = strdup(argv[optind]);
+		char *ptr, *copy = strdup(argv[optind]), *arg = copy;
 
 		if((ptr = strchr(arg, ':'))) {
 			*ptr = '\0';
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
 		} else {
 			port = atoi(arg);
 		}
-		free(arg);
+		free(copy);
 
 		if(o_udp || proto == PROTO_UDP) {
 			sd = socket(PF_INET, SOCK_DGRAM, 0);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -446,6 +446,7 @@ void reload(int signum)
 		close_door(door);
 	}
 	list_free(doors);
+	doors = NULL;
 
 	res_cfg = parseconfig(o_cfg);
 

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1472,7 +1472,7 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 	char pkt_time[9];
 	PMList *lp;
 	knocker_t *attempt = NULL;
-	PMList *found_attempts = NULL;
+	PMList *found_attempts = NULL, *found_attempt;
 
 	if(lltype == DLT_EN10MB) {
 		eth = (struct ether_header*)packet;
@@ -1608,8 +1608,9 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 		found_attempts = list_add(found_attempts, NULL);
 	}
 
-	while (found_attempts != NULL) {
-		attempt = (knocker_t*)found_attempts->data;
+	for (found_attempt = found_attempts; found_attempt != NULL; found_attempt = found_attempt->next) {
+		attempt = (knocker_t*)found_attempt->data;
+		found_attempt->data = NULL;
 
 		if(attempt) {
 			int flagsmatch = flags_match(attempt->door, ip, tcp);
@@ -1662,9 +1663,9 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 				}
 			}
 		}
-
-		found_attempts = found_attempts->next;
 	}
+
+	list_free(found_attempts);
 }
 
 /* Compare ip against door target or all ips of our local interface

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -413,13 +413,11 @@ void cleanup(int signum)
 		unlink(o_pidfile);
 	}
 
-	if(myip) {
-		while(myips) {
-			if(myip->value)
-				free(myip->value);
-			myips = myip->next;
-			free(myip);
-		}
+	while(myip) {
+		if(myip->value)
+			free(myip->value);
+		myip = myip->next;
+		free(myip);
 	}
 
 	exit(signum);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -413,7 +413,7 @@ void cleanup(int signum)
 		unlink(o_pidfile);
 	}
 
-	if(myips) {
+	if(myip) {
 		while(myips) {
 			if(myip->value)
 				free(myip->value);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -529,7 +529,12 @@ char* trim(char *str)
 		memmove(str, pch, (strlen(pch) + 1));
 	}
 
-	pch = (char*)(str + (strlen(str) - 1));
+	size_t len = strlen(str);
+	if (len == 0) {
+		return str;
+	}
+
+	pch = (char*)(str + (len - 1));
 	while(isspace(*pch)) {
 		pch--;
 	}

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -455,6 +455,7 @@ void reload(int signum)
 	/* close the log file */
 	if(logfd) {
 		fclose(logfd);
+		logfd = NULL;
 	}
 
 	if(res_cfg) {

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -448,6 +448,9 @@ void reload(int signum)
 	list_free(doors);
 	doors = NULL;
 
+	list_free(attempts);
+	attempts = NULL;
+
 	res_cfg = parseconfig(o_cfg);
 
 	vprint("Closing log file: %s\n", o_logfile);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -399,7 +399,7 @@ void dprint_sequence(opendoor_t *door, char *fmt, ...)
 /* Signal handlers */
 void cleanup(int signum)
 {
-	ip_literal_t *myip = myips;
+	ip_literal_t *myip = myips, *next;
 	int status;
 
 	vprint("waiting for child processes...\n");
@@ -413,10 +413,11 @@ void cleanup(int signum)
 		unlink(o_pidfile);
 	}
 
-	while(myip) {
-		if(myip->value)
+	for (; myip; myip = next) {
+		if (myip->value) {
 			free(myip->value);
-		myip = myip->next;
+		}
+		next = myip->next;
 		free(myip);
 	}
 

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1139,8 +1139,10 @@ size_t realloc_strcat(char **dest, const char *src, size_t size)
 {
 	size_t needed_size;
 	size_t new_size;
+	char *orig = *dest;
 
 	if(size == 0) {
+		free(orig);
 		return 0;
 	}
 
@@ -1153,6 +1155,7 @@ size_t realloc_strcat(char **dest, const char *src, size_t size)
 	if(new_size != size) {
 		*dest = (char*)realloc(*dest, new_size);
 		if(*dest == NULL) {
+			free(orig);
 			return 0;
 		}
 	}

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -573,7 +573,7 @@ int parseconfig(char *configfile)
 			ptr = line;
 			ptr++;
 			strncpy(section, ptr, sizeof(section));
-			section[strlen(section)-1] = '\0';
+			section[sizeof(section)-1] = '\0';
 			dprint("config: new section: '%s'\n", section);
 			if(!strlen(section)) {
 				fprintf(stderr, "config: line %d: bad section name\n", linenum);

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1453,7 +1453,10 @@ void process_attempt(knocker_t *attempt)
 		 * Note that here the door will eventually be closed in
 		 * get_new_one_time_sequence() if no more sequences are left */
 		if(attempt->door->one_time_sequences_fd) {
-			disable_used_one_time_sequence(attempt->door);
+			if (disable_used_one_time_sequence(attempt->door)) {
+				return;
+			}
+
 			get_new_one_time_sequence(attempt->door);
 
 			/* update pcap filter */


### PR DESCRIPTION
```
        /* close the log file */
        if(logfd) {
                fclose(logfd);                                   <-- the FILE logfd points to is freed
        }

        if(res_cfg) {
                exit(1);
        }

        vprint("Re-opening log file: %s\n", o_logfile);
        logprint("Re-opening log file: %s\n", o_logfile);                    <- if (logfd) is true and the stdio buffer, etc' are used-after-free 
```

EDIT: this is only 32f3628, found more