### PR TITLE
Fixed further use-after-free based on jvinet/knock#74.

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -444,8 +444,10 @@ void reload(int signum)
 	for(lp = doors; lp; lp = lp->next) {
 		door = (opendoor_t*)lp->data;
 		close_door(door);
+		lp->data = NULL;
 	}
 	list_free(doors);
+	doors = NULL;
 
 	res_cfg = parseconfig(o_cfg);
 
@@ -461,14 +463,14 @@ void reload(int signum)
 		exit(1);
 	}
 
-	vprint("Re-opening log file: %s\n", o_logfile);
-	logprint("Re-opening log file: %s\n", o_logfile);
-
 	/* re-open the log file */
 	logfd = fopen(o_logfile, "a");
 	if(logfd == NULL) {
 		perror("warning: cannot open logfile");
 	}
+
+	vprint("Re-opening log file: %s\n", o_logfile);
+	logprint("Re-opening log file: %s\n", o_logfile);
 
 	/* Fix issue #2 by regenerating the PCAP filter post config file re-read */
 	generate_pcap_filter();


### PR DESCRIPTION
Fixed additional use-after-free problem in knockd based on pull request #74 (and some additional changes):
1. lp->data pointer is freed in close_door() and freed again in list_free(doors) (double free)
2. doors point is not set NULL but freed in list_free(doors). Later in parseconfig() in function list_add(doors, door) it is not reallocated if pointer is not NULL. (use-after-free).
3. Moved logprint and vprint lines below reopeing of logfile, otherwise - with the change in #74 - the logprint output would never be logged.