### PR TITLE
Fix regression in parsing (#77)

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -574,6 +574,7 @@ int parseconfig(char *configfile)
 			ptr++;
 			strncpy(section, ptr, sizeof(section));
 			section[sizeof(section)-1] = '\0';
+			section[strlen(section)-1] = '\0';
 			dprint("config: new section: '%s'\n", section);
 			if(!strlen(section)) {
 				fprintf(stderr, "config: line %d: bad section name\n", linenum);


### PR DESCRIPTION
The null termination using sizeof() is still needed, because if the section is >= `sizeof(section)` bytes, then strlen() goes beyond the end of the buffer (the sizeof() makes the strlen() safe).