### PR TITLE
Permit a duplicate knock just from the previous stage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.9           - Permit ignoring duplicate packets.
 0.8           - Multiple fixes (#67, #77)
               - IPv6 support (Sebastien Valat)
 0.7.8         - Fix for Issue #33, #34 and #35 contributed by Alexander

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([knock], [0.8], [https://github.com/jvinet/knock/issues])
+AC_INIT([knock], [0.9], [https://github.com/jvinet/knock/issues])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign subdir-objects])
 
 AC_CONFIG_HEADER([config.h])

--- a/doc/knockd.1.in
+++ b/doc/knockd.1.in
@@ -196,6 +196,13 @@ interfere with (and thus invalidate) the knock.
 Separate multiple flags with commas (eg, TCPFlags = syn,ack,urg).  Flags can be
 explicitly excluded by a "!" (eg, TCPFlags = syn,!ack).
 .TP
+.B "AllowDupes"
+Ignore packets (that is, don't invalidate the entire knock), if the packet is a
+duplicate of the sequence stage we've just seen. This may be the case if our
+firewall is configured to drop packets (rather than respond with a rst), so we
+may receive multiple/duplicate TCP syn packets from the knocker, for a single
+stage.
+.TP
 .B "Target = <ip-address>"
 Use the specified IP address instead of the address determined for the
 \fBInterface\fP when matching the \fBSequence\fP.

--- a/src/knock.c
+++ b/src/knock.c
@@ -35,7 +35,7 @@
 #include <getopt.h>
 #include <fcntl.h>
 
-static char version[] = "0.8";
+static char version[] = "0.9";
 
 #define PROTO_TCP 1
 #define PROTO_UDP 2

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -63,7 +63,7 @@
 extern int daemon(int, int);
 #endif
 
-static char version[] = "0.8";
+static char version[] = "0.9";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -1825,8 +1825,17 @@ void sniff(u_char* arg, const struct pcap_pkthdr* hdr, const u_char* packet)
 			} else {
 				/* invalidate the knock sequence, it will be removed in the
 				 * next sniff() call.
+				 *
+				 * ... unless it matches a previous stage, in which case assume it's a dupe and ignore
 				 */
-				attempt->stage = -1;
+
+				if(attempt->stage > 0 &&
+						ip_proto == attempt->door->protocol[attempt->stage - 1] &&
+						dport == attempt->door->sequence[attempt->stage - 1]) {
+					dprint("got attempt, ip %s, matching previous stage - assuming duplicate packet\n", attempt->src);
+				} else {
+					attempt->stage = -1;
+				}
 			}
 		} else {
 			/* did they hit the first port correctly? */


### PR DESCRIPTION
This is similar to #72 (only spotted this after I'd written up my solution!), but without the same brute-force concerns.

The difference is that we permit (ignore) a duplicate packet only if it matches the previous stage of the current sequence. I've added more details in the docs:

https://github.com/jvinet/knock/blob/474330a961bba0cf95060aedceb34ff87d05abb1/doc/knockd.1.in#L199-L204


This also allows for browser based knocking, or knocking on a server who will drop packets, where (if we're using something like netcat) we'll send multiple TCP SYNs.